### PR TITLE
Update Size.java

### DIFF
--- a/Flickr4Java/src/main/java/com/flickr4java/flickr/photos/Size.java
+++ b/Flickr4Java/src/main/java/com/flickr4java/flickr/photos/Size.java
@@ -260,7 +260,7 @@ public class Size {
 
     public void setWidth(String width) {
 
-        if (width != null) {
+        if (!(width == null || "".equals(width))) {   // checking both null and empty
             setWidth(Integer.parseInt(width));
         }
     }
@@ -277,7 +277,7 @@ public class Size {
 
     public void setHeight(String height) {
 
-        if (height != null) {
+        if (!(height == null || "".equals(height))) {   // checking both null and empty
             setHeight(Integer.parseInt(height));
         }
     }


### PR DESCRIPTION
Flickr API now returns empty string for some height and widths of valid videos. Unfortunately the Size routines only checks for nulls. This validates that both the height and width are not null and not empty before converting the string values to a number.